### PR TITLE
Development polls

### DIFF
--- a/SpotBot-Docs/package-lock.json
+++ b/SpotBot-Docs/package-lock.json
@@ -6701,10 +6701,23 @@
         "node": ">=8"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
     },
     "node_modules/ipaddr.js": {
@@ -7146,6 +7159,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -10791,16 +10810,16 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+      "integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
       "dev": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -16980,11 +16999,23 @@
         }
       }
     },
-    "ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true
+    "ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "requires": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+          "dev": true
+        }
+      }
     },
     "ipaddr.js": {
       "version": "2.0.1",
@@ -17301,6 +17332,12 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
     },
     "jsesc": {
       "version": "2.5.2",
@@ -19979,12 +20016,12 @@
       }
     },
     "socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+      "integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
       "dev": true,
       "requires": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       }
     },

--- a/SpotBot/src/app.service.ts
+++ b/SpotBot/src/app.service.ts
@@ -1,11 +1,16 @@
 import {Guild, Message, GuildMember, PartialGuildMember } from 'discord.js'
 import { singleton } from 'tsyringe';
 import { Poll } from './appCommands/poll';
+import { LogService } from './services/log.service';
 
 @singleton()
 export class AppService {
 
-    constructor() {}
+    private logger: LogService;
+
+    constructor(logger: LogService) {
+        this.logger = logger;
+    }
 
     private _guild: Guild;
 
@@ -38,7 +43,7 @@ export class AppService {
 
     public handleAppCommand = (command: string, message: Message, messageContent: string) => {
         if (command.includes('poll')) {
-            const poll = new Poll();
+            const poll = new Poll(this.logger, this.guild);
 
             poll.startPoll(message, messageContent);
         }

--- a/SpotBot/src/app.service.ts
+++ b/SpotBot/src/app.service.ts
@@ -1,5 +1,6 @@
-import {Guild, Message, Client, GuildMember, PartialGuildMember, TextChannel} from 'discord.js'
+import {Guild, Message, GuildMember, PartialGuildMember } from 'discord.js'
 import { singleton } from 'tsyringe';
+import { Poll } from './appCommands/poll';
 
 @singleton()
 export class AppService {
@@ -15,7 +16,11 @@ export class AppService {
         this._guild = value;
     }
 
-    extractCommand = (message: Message, commandPrefix: string) => {
+    commandKeywords =  [
+        'poll'
+    ]
+
+    public extractCommand = (message: Message, commandPrefix: string) => {
         const command = message.content
             .trim()
             .substring(commandPrefix.length)
@@ -29,6 +34,14 @@ export class AppService {
         );
 
         return [command, messageContent]
+    }
+
+    public handleAppCommand = (command: string, message: Message, messageContent: string) => {
+        if (command.includes('poll')) {
+            const poll = new Poll();
+
+            poll.startPoll(message, messageContent);
+        }
     }
 }
 

--- a/SpotBot/src/app.ts
+++ b/SpotBot/src/app.ts
@@ -70,6 +70,11 @@ CLIENT.on('message', async (message) => {
             return;
         }
 
+        if (appService.commandKeywords.includes(command)) {
+            appService.handleAppCommand(command, message, messageContent);
+            return;
+        }
+
         // TODO: handle this better
         if (
             configService.configKeywords.includes(command) && 

--- a/SpotBot/src/appCommands/poll.ts
+++ b/SpotBot/src/appCommands/poll.ts
@@ -1,0 +1,33 @@
+import { Message } from "discord.js";
+
+export class Poll {
+    
+    pollChannelId: string;
+
+    constructor() {
+        
+    }
+
+    public startPoll = async (message: Message, messageContent: string) => {
+        if(!messageContent.includes('<#') && !messageContent.includes('>')) {
+            console.log('No additional poll command params');
+            this.pollChannelId = message.channel.id;
+        } else {
+            this.pollChannelId = messageContent.replace(/[^0-9]/g,''); 
+
+            if (message.guild.channels.cache.find(c => c.id === this.pollChannelId) === undefined) {
+                message.channel.send("Unable to find a channel that matches. Please try again.");
+                return;
+            }
+        }
+
+        message.channel.send(`On it! I'll use <#${this.pollChannelId}> for the poll.\r\nEnter 'quit-poll' to abandon this poll at any time.`);
+
+        await this.getPollContent(message);
+    }
+
+    private getPollContent = async (message: Message) => {
+
+    }
+
+}

--- a/SpotBot/src/appCommands/poll.ts
+++ b/SpotBot/src/appCommands/poll.ts
@@ -1,11 +1,21 @@
-import { Message } from "discord.js";
+import { Collection, Guild, Message, TextChannel } from "discord.js";
+import { LogService } from "../services/log.service";
 
 export class Poll {
     
-    pollChannelId: string;
+    private pollChannelId: string;
+    private pollContent: string;
+    private pollReactions: string[];
+    private quit: boolean = false;
+    private botMessagesToDelete: Message[] = [];
+    private userMessagesToDelete: Collection<string, Message>[] = [];
 
-    constructor() {
-        
+    private logger: LogService;
+    private guild: Guild;
+
+    constructor(logger: LogService, guild: Guild) {
+        this.logger = logger;
+        this.guild = guild;
     }
 
     public startPoll = async (message: Message, messageContent: string) => {
@@ -15,19 +25,238 @@ export class Poll {
         } else {
             this.pollChannelId = messageContent.replace(/[^0-9]/g,''); 
 
-            if (message.guild.channels.cache.find(c => c.id === this.pollChannelId) === undefined) {
+            if (this.guild.channels.cache.find(c => c.id === this.pollChannelId) === undefined) {
                 message.channel.send("Unable to find a channel that matches. Please try again.");
                 return;
             }
         }
 
-        message.channel.send(`On it! I'll use <#${this.pollChannelId}> for the poll.\r\nEnter 'quit-poll' to abandon this poll at any time.`);
+        await message.channel.send(`On it! I'll use <#${this.pollChannelId}> for the poll.\r\nEnter 'quit-poll' to abandon this poll at any time.`)
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
 
-        await this.getPollContent(message);
+        await message.channel.send(`For the sake of clarity, here is what a SpotBot poll will look like:\r\n⁠`)
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
+
+        const demoPoll = `Pick a version!\r\n:blue_circle: = Blue\r\n:red_circle: = Red`;
+        await message.channel.send(demoPoll)
+            .then( async (m) => {
+                await m.react('🔵');
+                await m.react('🔴'); 
+
+                this.botMessagesToDelete.push(m);
+            });
+
+        await message.channel.send('⁠')
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
+
+        await this.getPollReactions(message);
+        if (this.quit !== true) await this.getPollContent(message);
+        if (this.quit !== true) await this.verifyPoll(message);
+        if (this.quit !== true) await this.postPoll(message);
+        if (this.quit === true) await this.quitPoll(message);
+        await this.cleanUpPoll(message);
+    }
+
+    private getPollReactions = async (message: Message) => {
+        //TODO: 30 emoji max
+        
+        const prompt: string = '**What emoji or reactions would you like to use as responses for your poll?**\r\n\r\n'+
+        `Try to stick to server or common emoji. If you are a Discord Nitro subscriber, SpotBot may not have access to same emoji that you do.\r\n`+
+        `Submit emoji ALL AT ONCE, separated by spaces. Your next message to this channel will be used.`        
+
+        await message.channel.send(prompt)
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
+
+        const msg_filter = (m: Message) => m.author.id === message.author.id;
+
+        await message.channel.awaitMessages(msg_filter, { max: 1, time: 300000, errors: ['time']})
+            .then(async (collected) => {
+                this.userMessagesToDelete.push(collected);
+                
+                if (collected.first().content.includes('quit-poll')) {
+                    this.quit = true;
+                    return;
+                };
+                
+                this.pollReactions = collected.first().content.split(' ');
+                let failedReaction = false;
+
+                await message.channel.send(`Awesome! Testing them by reacting to this message...`)
+                    .then(async (m) => {
+                        for await (const reaction of this.pollReactions) {
+                            if (!failedReaction) {
+                                await m.react(reaction).catch(() => {
+                                    failedReaction = true
+                                });
+                            }
+                        }
+
+                        this.botMessagesToDelete.push(m);
+                    })
+
+                if (failedReaction) {
+                    const errorMsgContent: string = `An error occurred... If you tried to use a Discord Nitro feature, `+
+                    `remember that bots can't use emoji from servers we don't have access to.`;
+                    
+                    await message.channel.send(errorMsgContent)
+                        .then(m => {
+                            this.botMessagesToDelete.push(m);
+                        });
+
+                    this.quit = true;
+                }
+            })
+            .catch(() => {
+                console.log('Emoji collection error error occurred.');
+            })
+            .finally(() => {
+
+            });
     }
 
     private getPollContent = async (message: Message) => {
+        const pollContentPrompt = `Almost done! What you would like the poll to say? Your next message will be used.\r\n\r\n` +
+        `**Don't forget the "reaction" = "reponse" explanation!\r\n**` +
+        `Ex: \r\n🟡 = Pikachu`;
+        
+        await message.channel.send(pollContentPrompt)
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
 
+        const msg_filter = (m: Message) => m.author.id === message.author.id;
+        await message.channel.awaitMessages(msg_filter, { max: 1, time: 300000, errors: ['time']})
+            .then(async (collected) => {
+                this.userMessagesToDelete.push(collected);
+
+                if (collected.first().content.includes('quit-poll')) {
+                    this.quit = true;
+                    return;
+                };
+                
+                this.pollContent = collected.first().content;
+
+                // TODO: Validate poll?
+
+            })
+            .catch(() => {
+                console.log('Poll content collection error error occurred.');
+            })
+            .finally(() => {
+
+            });
     }
 
+    private verifyPoll = async (message: Message) => {
+        await message.channel.send(`Generating poll preview...\r\n\r\n⁠`)
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            })
+
+        let failedReaction = false;
+        await message.channel.send(this.pollContent)
+            .then( async (m) => {
+                for await (const reaction of this.pollReactions) {
+                    if (!failedReaction) {
+                        await m.react(reaction).catch(() => {
+                            failedReaction = true
+                        });
+                    }
+                }
+                this.botMessagesToDelete.push(m);
+            })
+
+        await message.channel.send('⁠')
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
+
+        await message.channel.send('If eveything looks good, add an ✅ to confirm or an ❌ to reject.')
+            .then( async (m) => {
+                await m.react('✅');
+                await m.react('❌');
+
+                this.botMessagesToDelete.push(m);
+
+                await m.awaitReactions(
+                    (reaction, user) => user.id == message.author.id && (reaction.emoji.name == '✅' || reaction.emoji.name == '❌'),
+                    { max: 1, time: 50000, errors: ['time'] }
+                )
+                    .then(async (collected) => { 
+                        if (collected.first().emoji.name === '✅') {
+                            await message.channel.send("Awesome! I'll get that posted right away.")
+                                .then(msg => {
+                                    this.botMessagesToDelete.push(msg);
+                                });
+                        } else {
+                            await message.channel.send("Dang... Sorry about that. Please use `;;poll` and we will try again.")
+                                .then(msg => {
+                                    this.botMessagesToDelete.push(msg);
+                                });
+                            this.quit = true;
+                        }
+                    })
+                    .catch( async e => {
+                        await message.channel.send('Verification timeout...')
+                            .then(m => {
+                                this.botMessagesToDelete.push(m);
+                            });
+                        this.quit = true;
+                    })
+            })
+    }
+
+    private postPoll = async (message: Message) => {
+        await (this.guild.channels.cache.get(this.pollChannelId) as TextChannel)
+            .send(this.pollContent)
+            .then( async (m) => {
+                for await (const reaction of this.pollReactions) {
+                    await m.react(reaction)
+                        .catch(async (m) => {
+                            m.delete();
+                            await message.channel.send('An expected error occured. I deleted the half-made poll. My apologies.');
+                        });
+                }
+            });
+        
+        await message.channel.send("Posted!")
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
+    }
+
+    private quitPoll = async (message: Message) => {
+        message.channel.send('Quitting poll...')
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
+    }
+
+    private cleanUpPoll = async (message: Message) => {
+        await message.channel.send("I'll start cleaning up these poll creation messages. This can take a sec...")
+            .then(m => {
+                this.botMessagesToDelete.push(m);
+            });
+
+        this.botMessagesToDelete.forEach(msg => {
+            msg.delete();
+        })
+
+        this.userMessagesToDelete.forEach(msg => {
+            msg.forEach(m => m.delete());
+        })
+
+        if (!this.quit) {
+            const logMessage = `Poll created by user: <@${message.author.id}>`;
+            this.logger.logToLogsChannel(this.guild, logMessage);
+        }
+    }
 }

--- a/SpotBot/src/services/configuration/configMessageHelpers.ts
+++ b/SpotBot/src/services/configuration/configMessageHelpers.ts
@@ -32,7 +32,7 @@ export const configureWelcomeChannel = async (configChannel: TextChannel): Promi
     configChannel.send(
         `Would you like to configure a welcome channel?\r\n`+
         `SpotBot can send welcome messages to new server members using this channel.\r\n`+
-        `Note, all welcome messages start with "Hey, @USER!" and then a custom or default message.`+
+        `Note, all welcome messages start with "Hey, @USER!" and then a custom or default message.\r\n`+
         `Respond "yes" or "no" to enable SpotBot welcoming.`
     );
 

--- a/SpotBot/src/services/configuration/configuration.service.ts
+++ b/SpotBot/src/services/configuration/configuration.service.ts
@@ -164,7 +164,9 @@ export class ConfigurationService {
                 await configChannel.send("A welcome channel has been created! Feel free organize it into a category later.");
                 await configChannel.send("Use command `;;configure welcome` later to set a custom welcome message if you would like.");
             } else if (r.includes("<#")) {
-                defaults.id = r.replace(/[^a-zA-Z0-9_-]/g,''); 
+                
+                //TODO: handle cases like "yes #member-welcome 2323423423423"
+                defaults.id = r.replace(/[^0-9]/g,''); 
                 console.log(`Saving welcome channel to config using id: ${defaults.id}`);
                 await configChannel.send("Saved! Use command `;;configure welcome` later to set a custom welcome message if you would like.");
                 const specifiedChannel = this.guild.channels.cache.find((channel: TextChannel) => channel.id === defaults.id);

--- a/SpotBot/src/services/log.service.ts
+++ b/SpotBot/src/services/log.service.ts
@@ -1,4 +1,4 @@
-import {TextChannel, Message, Client}from 'discord.js'
+import {TextChannel, Message, Client, Guild}from 'discord.js'
 import { autoInjectable } from 'tsyringe';
 
 //TODO: save log channel id to file as part of configuration 
@@ -12,7 +12,14 @@ export class LogService {
      */
     constructor() {
 
-        
+    }
+
+    public logToLogsChannel = (guild: Guild, logMessage: string) => {
+        // Remove hard coded 'bot-logs' and get it from config
+
+        (guild.channels.cache.get(guild.channels.cache.find(
+            (channel: TextChannel) => channel.name === 'bot-logs'
+        ).id) as TextChannel).send(logMessage);
     }
 
     private generateLogChannel = () => {


### PR DESCRIPTION
Added polls to SpotBot!

Using the `;;poll` or `;;poll #channel` command, a server admin can ask SpotBot to start a poll:

* Will ask for emojis to be used
    * Will remind to use emotes that SpotBot has access to (if nitro)
    * Separated by spaces
* Will message that the next message from the user will be used as the poll
    * Will remind to include emote key
    * Will give example
* Will then prompt “generating poll preview”
* Will post poll and react to it and ask for confirmation
* Will post “cleaning up poll creating messages”
* Will post poll